### PR TITLE
Version wasn't string, fix hist/settings files

### DIFF
--- a/poc_viewer.py
+++ b/poc_viewer.py
@@ -1,19 +1,20 @@
 #! /usr/bin/env python3
-pocUtilsVersion = 2.2.1
+pocUtilsVersion = '2.2.1'
     
 import argparse
-try: import configparser
-except: import ConfigParser as configparser
-import sys
+import cmd
+import glob
 import json
 import os
 import platform
-from collections import OrderedDict
-import traceback
-import glob
 import subprocess
+import sys
+import traceback
+from collections import OrderedDict
 
-import cmd
+try: import configparser
+except: import ConfigParser as configparser
+
 try:
     import readline
     import atexit
@@ -280,7 +281,8 @@ class G2CmdShell(cmd.Cmd):
         self.currentReviewList = None
 
         #--get settings
-        settingsFileName = '.' + sys.argv[0].lower().replace('.py','') + '_settings'
+        settingsFileName = '.' + os.path.basename(sys.argv[0].lower().replace('.py','')) + '_settings'
+
         self.settingsFileName = os.path.join(os.path.expanduser("~"), settingsFileName)
         try: self.settingsFileData = json.load(open(self.settingsFileName))
         except: self.settingsFileData = {}
@@ -339,7 +341,7 @@ class G2CmdShell(cmd.Cmd):
 
         if readline:
             global histfile
-            histFileName = '.' + sys.argv[0].lower().replace('.py','') + '_history'
+            histFileName = '.' + os.path.basename(sys.argv[0].lower().replace('.py','')) + '_history'
             histfile = os.path.join(os.path.expanduser("~"), histFileName)
             if not os.path.isfile(histfile):
                 open(histfile, 'a').close()


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #nnn

## Why was change needed

pocUtilsVersion needed to be a string. 

histFileName was using histFileName = '.' + sys.argv[0].lower().replace('.py','') + '_history' and similar for settingsFileName. This doesn't work for Python3 when using ./poc_Viewer.py to launch the script. Modified both to correct syntax for launching with ./ and python3 poc_viewer.py

## What does change improve


